### PR TITLE
Script to run tests locally

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # 3.9+ is not currently supported due to https://github.com/freach/udatetime/issues/32
         python-version: ["3.7", "3.8"]
     steps:
       - uses: actions/checkout@v3
@@ -22,8 +23,9 @@ jobs:
         run: |
           python3 -m pip install virtualenv
           git clone --depth=1 https://github.com/StackStorm/st2.git /tmp/st2
-          # Required to get all wheels building
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends libsasl2-dev python3-dev libldap2-dev libssl-dev
+          sudo apt-get update
+          # Required to get python-ldap wheel building
+          sudo apt-get install -y --no-install-recommends libsasl2-dev python3-dev libldap2-dev libssl-dev
 
       - name: Run Tests
         run: ST2_REPO_PATH=/tmp/st2 /tmp/st2/st2common/bin/st2-run-pack-tests -p . -c

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ openstacksdk
 python-openstackclient
 tabulate
 requests
+
+# Workaround OS packaging problems with Python-ldap on unit tests
+setuptools~=62.0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -ex
+set -e
 
 REPO_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -ex
+
+REPO_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+export ST2_REPO_PATH="/tmp/st2"
+if [ ! -d "$ST2_REPO_PATH" ]; then
+    git clone --depth=1 https://github.com/stackstorm/st2.git "$ST2_REPO_PATH"
+fi
+
+"$ST2_REPO_PATH/st2common/bin/st2-run-pack-tests" -p "$REPO_DIR" -c


### PR DESCRIPTION
Add steps to run tests locally

You will need to install the LDAP requirements / workarounds manually to run this script:
```
libsasl2-dev python3-dev libldap2-dev libssl-dev python3-udatetime
```