### PR TITLE
Add support for deleting projects

### DIFF
--- a/actions/project.delete.yaml
+++ b/actions/project.delete.yaml
@@ -1,14 +1,24 @@
 ---
 description: Delete Openstack Project
 enabled: true
-entry_point: src/project.py
+entry_point: src/project_action.py
 name: project.delete
 parameters:
   submodule:
     default: project_delete
     immutable: true
     type: string
-  project:
-    description: Project Name or ID to delete
+  cloud_account:
+    description: The clouds.yaml account to use whilst performing this action
+    default: ''
+    required: true
     type: string
+  project_name:
+    description: Project Name to delete
+    type: string
+    default: ''
+  project_id:
+    description: Project ID to delete, this takes preference over name
+    type: string
+    default: ''
 runner_type: python-script

--- a/lib/openstack_identity.py
+++ b/lib/openstack_identity.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from openstack.exceptions import ResourceNotFound
 from openstack.identity.v3.project import Project
 from missing_mandatory_param_error import MissingMandatoryParamError
 from openstack_connection import OpenstackConnection
@@ -26,7 +27,39 @@ class OpenstackIdentity:
         with OpenstackConnection(cloud_account) as conn:
             return conn.identity.create_project(
                 name=project_details.name,
+                # This is intentionally hard-coded as it's very rare we create something in another domain
+                domain_id="default",
                 description=project_details.description,
-                domain_id=project_details.domain_id,
                 is_enabled=project_details.is_enabled,
             )
+
+    @staticmethod
+    def delete_project(cloud_account: str, project_details: ProjectDetails) -> bool:
+        """
+        :param cloud_account: The clouds entry to use
+        :param project_details: A datastructure containing all the project details
+        :return: True if the project was deleted, False if the operation failed
+        """
+        proj_identifier = (
+            project_details.name.strip() if project_details.name.strip() else None
+        )
+        proj_identifier = (
+            project_details.openstack_id.strip()
+            if project_details.openstack_id
+            else proj_identifier
+        )
+
+        if not proj_identifier:
+            raise MissingMandatoryParamError(
+                "A project name or project ID must be provided"
+            )
+
+        ignore_missing = False
+        with OpenstackConnection(cloud_account) as conn:
+            try:
+                result = conn.identity.delete_project(
+                    project=proj_identifier, ignore_missing=ignore_missing
+                )
+                return result is None  # Where None == success
+            except ResourceNotFound:
+                return False

--- a/lib/structs/create_project.py
+++ b/lib/structs/create_project.py
@@ -5,6 +5,6 @@ from typing import Optional
 @dataclass
 class ProjectDetails:
     name: str
-    description: str
-    is_enabled: bool
-    domain_id: Optional[str] = None
+    description: str = ""
+    is_enabled: Optional[bool] = None
+    openstack_id: Optional[str] = None

--- a/tests/lib/test_openstack_identity.py
+++ b/tests/lib/test_openstack_identity.py
@@ -1,49 +1,127 @@
-from unittest import mock
-from unittest.mock import NonCallableMock
+import unittest
+from unittest.mock import NonCallableMock, patch
 
 from nose.tools import raises
+from openstack.exceptions import ResourceNotFound
 
 from openstack_identity import OpenstackIdentity
 from missing_mandatory_param_error import MissingMandatoryParamError
 from structs.create_project import ProjectDetails
 
 
-@raises(MissingMandatoryParamError)
-def test_create_project_name_missing_throws():
+class OpenstackIdentityTests(unittest.TestCase):
     """
-    Tests calling the API wrapper without a domain will throw
+    Runs various tests to ensure we are using the Openstack
+    Identity module in the expected way
     """
-    OpenstackIdentity().create_project(
-        "", ProjectDetails(name="", description="", is_enabled=False)
-    )
 
+    def setUp(self) -> None:
+        connection_patch = patch("openstack_identity.OpenstackConnection")
+        self.mocked_connection = connection_patch.start()
+        self.addCleanup(connection_patch.stop)
+        self.identity_api = (
+            self.mocked_connection.return_value.__enter__.return_value.identity
+        )
 
-def test_forwards_create_project():
-    """
-    Tests that the params and result are forwarded as-is to/from the
-    create_project API
-    """
-    instance = OpenstackIdentity()
+    @staticmethod
+    @raises(MissingMandatoryParamError)
+    def test_create_project_name_missing_throws():
+        """
+        Tests calling the API wrapper without a domain will throw
+        """
+        OpenstackIdentity().create_project(
+            "", ProjectDetails(name="", description="", is_enabled=False)
+        )
 
-    expected_details = ProjectDetails(
-        name=NonCallableMock(),
-        description=NonCallableMock(),
-        is_enabled=NonCallableMock(),
-        domain_id=NonCallableMock(),
-    )
+    def test_create_project_forwards_result(self):
+        """
+        Tests that the params and result are forwarded as-is to/from the
+        create_project API
+        """
+        instance = OpenstackIdentity()
 
-    with mock.patch("openstack_identity.OpenstackConnection") as patched_connection:
-        identity_api = patched_connection.return_value.__enter__.return_value.identity
+        expected_details = ProjectDetails(
+            name=NonCallableMock(),
+            description=NonCallableMock(),
+            is_enabled=NonCallableMock(),
+        )
+
         found = instance.create_project(
             cloud_account="test", project_details=expected_details
         )
 
-        patched_connection.assert_called_once_with("test")
+        self.mocked_connection.assert_called_once_with("test")
 
-        assert found == identity_api.create_project.return_value
-        identity_api.create_project.assert_called_once_with(
+        assert found == self.identity_api.create_project.return_value
+        self.identity_api.create_project.assert_called_once_with(
             name=expected_details.name,
+            domain_id="default",
             description=expected_details.description,
-            domain_id=expected_details.domain_id,
             is_enabled=expected_details.is_enabled,
         )
+
+    @staticmethod
+    @raises(MissingMandatoryParamError)
+    def test_delete_project_throws_whitespace_args():
+        """
+        Test that if the user doesn't provide meaningful args to delete we throw
+        """
+        # Intentional spaces
+        details = ProjectDetails(name=" ", openstack_id=" ")
+        OpenstackIdentity().delete_project("", details)
+
+    def test_delete_project_successful_with_name_or_id(self):
+        """
+        Tests delete project will use name or Openstack ID if provided
+        and will return the result
+        """
+        instance = OpenstackIdentity()
+        self.identity_api.delete_project.return_value = None
+        for details in [
+            ProjectDetails(name=NonCallableMock()),
+            ProjectDetails(name="", openstack_id=NonCallableMock()),
+        ]:
+
+            result = instance.delete_project(
+                cloud_account="test", project_details=details
+            )
+
+            assert result is True
+            expected_param = (
+                details.name.strip() if details.name else details.openstack_id.strip()
+            )
+            self.identity_api.delete_project.assert_called_once_with(
+                project=expected_param, ignore_missing=False
+            )
+            self.identity_api.delete_project.reset_mock()
+
+    def test_delete_project_uses_id_over_name(self):
+        """
+        Checks an ID is used over a project name, this is generally safer
+        as it's a UUID so hard to mistype
+        """
+        instance = OpenstackIdentity()
+        expected_details = ProjectDetails(
+            name=NonCallableMock(), openstack_id=NonCallableMock()
+        )
+        self.identity_api.delete_project.return_value = None
+
+        result = instance.delete_project(
+            cloud_account="test", project_details=expected_details
+        )
+
+        assert result is True
+        self.identity_api.delete_project.assert_called_once_with(
+            project=expected_details.openstack_id.strip(), ignore_missing=False
+        )
+
+    def test_delete_project_handles_resource_not_found(self):
+        """
+        Tests that the delete method can handle resource not found. This is
+        enabled, so it's easier to tell between a None (success) type and a
+        failure
+        """
+        instance = OpenstackIdentity()
+        self.identity_api.delete_project.side_effect = ResourceNotFound
+        result = instance.delete_project("", ProjectDetails(name="test"))
+        assert result is False

--- a/tests/test_project_action.py
+++ b/tests/test_project_action.py
@@ -7,7 +7,22 @@ from tests.openstack_action_test_case import OpenstackActionTestCase
 
 
 class TestActionProject(OpenstackActionTestCase):
+    """
+    Unit tests the Project.* actions
+    """
+
     action_cls = ProjectAction
+
+    # pylint: disable=invalid-name
+    def setUp(self):
+        """
+        Initialises the API mock used in the unit tests
+        """
+        super().setUp()
+        self.identity_mock = create_autospec(OpenstackIdentity)
+        self.action: ProjectAction = self.get_action_instance(
+            api_mock=self.identity_mock
+        )
 
     def test_project_action_can_be_instantiated(self):
         """
@@ -18,36 +33,43 @@ class TestActionProject(OpenstackActionTestCase):
 
     def test_create_project_when_successful(self):
         """
-        Tests that find domain forwards the result as-is when a domain is found
+        Tests that create project forwards the result when successful
         """
-        mock = create_autospec(OpenstackIdentity)
-        action: ProjectAction = self.get_action_instance(api_mock=mock)
-
         expected_proj_params = {
             i: NonCallableMock() for i in ["name", "description", "is_enabled"]
         }
         # Check that default gets hard-coded in too
-        packaged_proj = ProjectDetails(**expected_proj_params, domain_id="default")
+        packaged_proj = ProjectDetails(**expected_proj_params)
 
-        returned_values = action.project_create(
+        returned_values = self.action.project_create(
             cloud_account="foo", **expected_proj_params
         )
-        mock.create_project.assert_called_once_with(
+        self.identity_mock.create_project.assert_called_once_with(
             cloud_account="foo", project_details=packaged_proj
         )
 
         assert returned_values[0] is True
-        assert returned_values[1] == mock.create_project.return_value
+        assert returned_values[1] == self.identity_mock.create_project.return_value
 
     def test_project_create_when_failed(self):
         """
         Tests that create domain returns None and an error
         when the domain is not found
         """
-        mock = create_autospec(OpenstackIdentity)
-        mock.create_project.return_value = None
+        self.identity_mock.create_project.return_value = None
 
-        action: ProjectAction = self.get_action_instance(api_mock=mock)
-        returned_values = action.project_create(*{NonCallableMock() for _ in range(4)})
+        returned_values = self.action.project_create(
+            *{NonCallableMock() for _ in range(4)}
+        )
         assert returned_values[0] is False
         assert returned_values[1] is None
+
+    def test_project_delete_success(self):
+        """
+        Tests that on successful deletion it returns the correct status and string
+        """
+        self.identity_mock.delete_project.return_value = True
+        returned_values = self.action.project_delete(
+            NonCallableMock(), NonCallableMock(), NonCallableMock()
+        )
+        assert returned_values == (True, "")


### PR DESCRIPTION
Adds support for deleting projects.
Drops domain_id from the struct and hard-codes the one place where it's
required, since we don't create projects outside default.