### PR TITLE
Drop seperate ID and name fields for proj delete

### DIFF
--- a/actions/project.delete.yaml
+++ b/actions/project.delete.yaml
@@ -13,12 +13,9 @@ parameters:
     default: ''
     required: true
     type: string
-  project_name:
-    description: Project Name to delete
+  project_identifier:
+    description: Project Name or Openstack ID to delete
     type: string
     default: ''
-  project_id:
-    description: Project ID to delete, this takes preference over name
-    type: string
-    default: ''
+    required: true
 runner_type: python-script

--- a/actions/src/project_action.py
+++ b/actions/src/project_action.py
@@ -26,7 +26,7 @@ class ProjectAction(OpenstackAction):
         }
 
     def project_delete(
-        self, cloud_account: str, project_name: Optional[str], project_id: Optional[str]
+        self, cloud_account: str, project_identifier: str
     ) -> Tuple[bool, str]:
         """
         Deletes a project
@@ -36,8 +36,7 @@ class ProjectAction(OpenstackAction):
         :return: The result of the operation
         """
         delete_ok = self._api.delete_project(
-            cloud_account=cloud_account,
-            project_details=ProjectDetails(name=project_name, openstack_id=project_id),
+            cloud_account=cloud_account, project_identifier=project_identifier
         )
         # Currently, we only handle one error, other throws will propagate upwards
         err = "" if delete_ok else "The specified result was not found"

--- a/lib/openstack_identity.py
+++ b/lib/openstack_identity.py
@@ -34,22 +34,14 @@ class OpenstackIdentity:
             )
 
     @staticmethod
-    def delete_project(cloud_account: str, project_details: ProjectDetails) -> bool:
+    def delete_project(cloud_account: str, project_identifier: str) -> bool:
         """
         :param cloud_account: The clouds entry to use
-        :param project_details: A datastructure containing all the project details
+        :param project_identifier: The name or Openstack ID for the project
         :return: True if the project was deleted, False if the operation failed
         """
-        proj_identifier = (
-            project_details.name.strip() if project_details.name.strip() else None
-        )
-        proj_identifier = (
-            project_details.openstack_id.strip()
-            if project_details.openstack_id
-            else proj_identifier
-        )
-
-        if not proj_identifier:
+        project_identifier = project_identifier.strip()
+        if not project_identifier:
             raise MissingMandatoryParamError(
                 "A project name or project ID must be provided"
             )
@@ -58,7 +50,7 @@ class OpenstackIdentity:
         with OpenstackConnection(cloud_account) as conn:
             try:
                 result = conn.identity.delete_project(
-                    project=proj_identifier, ignore_missing=ignore_missing
+                    project=project_identifier, ignore_missing=ignore_missing
                 )
                 return result is None  # Where None == success
             except ResourceNotFound:

--- a/tests/lib/test_openstack_identity.py
+++ b/tests/lib/test_openstack_identity.py
@@ -67,8 +67,7 @@ class OpenstackIdentityTests(unittest.TestCase):
         Test that if the user doesn't provide meaningful args to delete we throw
         """
         # Intentional spaces
-        details = ProjectDetails(name=" ", openstack_id=" ")
-        OpenstackIdentity().delete_project("", details)
+        OpenstackIdentity().delete_project("", project_identifier=" \t")
 
     def test_delete_project_successful_with_name_or_id(self):
         """
@@ -77,42 +76,15 @@ class OpenstackIdentityTests(unittest.TestCase):
         """
         instance = OpenstackIdentity()
         self.identity_api.delete_project.return_value = None
-        for details in [
-            ProjectDetails(name=NonCallableMock()),
-            ProjectDetails(name="", openstack_id=NonCallableMock()),
-        ]:
 
-            result = instance.delete_project(
-                cloud_account="test", project_details=details
-            )
-
-            assert result is True
-            expected_param = (
-                details.name.strip() if details.name else details.openstack_id.strip()
-            )
-            self.identity_api.delete_project.assert_called_once_with(
-                project=expected_param, ignore_missing=False
-            )
-            self.identity_api.delete_project.reset_mock()
-
-    def test_delete_project_uses_id_over_name(self):
-        """
-        Checks an ID is used over a project name, this is generally safer
-        as it's a UUID so hard to mistype
-        """
-        instance = OpenstackIdentity()
-        expected_details = ProjectDetails(
-            name=NonCallableMock(), openstack_id=NonCallableMock()
-        )
-        self.identity_api.delete_project.return_value = None
-
+        identifier = NonCallableMock()
         result = instance.delete_project(
-            cloud_account="test", project_details=expected_details
+            cloud_account="test", project_identifier=identifier
         )
 
         assert result is True
         self.identity_api.delete_project.assert_called_once_with(
-            project=expected_details.openstack_id.strip(), ignore_missing=False
+            project=identifier.strip(), ignore_missing=False
         )
 
     def test_delete_project_handles_resource_not_found(self):
@@ -123,5 +95,5 @@ class OpenstackIdentityTests(unittest.TestCase):
         """
         instance = OpenstackIdentity()
         self.identity_api.delete_project.side_effect = ResourceNotFound
-        result = instance.delete_project("", ProjectDetails(name="test"))
+        result = instance.delete_project("", project_identifier="test")
         assert result is False

--- a/tests/test_project_action.py
+++ b/tests/test_project_action.py
@@ -70,6 +70,6 @@ class TestActionProject(OpenstackActionTestCase):
         """
         self.identity_mock.delete_project.return_value = True
         returned_values = self.action.project_delete(
-            NonCallableMock(), NonCallableMock(), NonCallableMock()
+            NonCallableMock(), NonCallableMock()
         )
         assert returned_values == (True, "")


### PR DESCRIPTION
This simplifies the user input, as splitting the fields provides little
gain but greatly increases the complexity.