### PR TITLE
Add an error string to find project

### DIFF
--- a/actions/src/project_action.py
+++ b/actions/src/project_action.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional, Dict, Callable
+from typing import Tuple, Optional, Dict, Callable, Union
 
 from openstack.identity.v3.project import Project
 
@@ -49,17 +49,18 @@ class ProjectAction(Action):
 
     def project_find(
         self, cloud_account: str, project_identifier: str
-    ) -> Tuple[bool, Optional[Project]]:
+    ) -> Tuple[bool, Union[Project, str]]:
         """
         find and return a given project's properties
         :param cloud_account: The account from the clouds configuration to use
         :param project_identifier: Name or Openstack ID
-        :return: (status (Bool), reason (String))
+        :return: status , Project object or error string
         """
         project = self._api.find_project(
             cloud_account=cloud_account, project_identifier=project_identifier
         )
-        return bool(project), project
+        output = project if project else "The project could not be found."
+        return bool(project), output
 
     def project_create(
         self,

--- a/tests/test_project_action.py
+++ b/tests/test_project_action.py
@@ -53,7 +53,7 @@ class TestActionProject(OpenstackActionTestCase):
 
     def test_project_create_when_failed(self):
         """
-        Tests that create domain returns None and an error
+        Tests that create project returns None and an error
         when the domain is not found
         """
         self.identity_mock.create_project.return_value = None
@@ -89,7 +89,8 @@ class TestActionProject(OpenstackActionTestCase):
         """
         self.identity_mock.find_project.return_value = None
         returned_values = self.action.project_find(NonCallableMock(), NonCallableMock())
-        assert returned_values == (False, None)
+        assert returned_values[0] is False
+        assert "could not be found" in returned_values[1]
 
     def test_run_dispatch(self):
         """


### PR DESCRIPTION
This makes it more obvious why it failed, rather than just saying
failed.