### PR TITLE
Convert find RBAC to search for RBACs

### DIFF
--- a/actions/network.rbac.search.yaml
+++ b/actions/network.rbac.search.yaml
@@ -1,11 +1,11 @@
 ---
-description: Finds a Network RBAC rule
+description: Searches for Network RBAC policies applying to a project
 enabled: true
 entry_point: src/network_actions.py
-name: network.rbac.find
+name: network.rbac.search
 parameters:
   submodule:
-    default: network_rbac_find
+    default: network_rbac_search
     immutable: true
     type: string
   cloud_account:
@@ -13,8 +13,8 @@ parameters:
     default: ''
     required: true
     type: string
-  rbac_identifier:
-    description: RBAC policy Name or ID
+  project_identifier:
+    description: The project name or ID these policies apply to
     required: True
     type: string
 runner_type: python-script

--- a/actions/src/network_actions.py
+++ b/actions/src/network_actions.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, Tuple, Optional, Callable
+from typing import Dict, Union, Tuple, Optional, Callable, List
 
 from openstack.network.v2.network import Network
 from openstack.network.v2.rbac_policy import RBACPolicy
@@ -41,18 +41,16 @@ class NetworkActions(Action):
         output = network if network else "The requested network could not be found"
         return bool(network), output
 
-    def network_rbac_find(
-        self, cloud_account: str, rbac_identifier: str
-    ) -> Tuple[bool, Union[RBACPolicy, str]]:
+    def network_rbac_search(
+        self, cloud_account: str, project_identifier: str
+    ) -> List[RBACPolicy]:
         """
-        Finds a given Network RBAC policy
+        Finds all Network RBAC policies belonging applying to a project
         :param cloud_account: The account from the clouds configuration to use
-        :param rbac_identifier: RBAC Name or ID
-        :return: status, RBAC Policy object or error message
+        :param project_identifier: The project this applies to
+        :return: List of found RBAC policies
         """
-        policy = self._api.find_network_rbac(cloud_account, rbac_identifier)
-        output = policy if policy else "The requested policy could not be found"
-        return bool(policy), output
+        return self._api.search_network_rbacs(cloud_account, project_identifier)
 
     # pylint: disable=too-many-arguments
     def network_create(

--- a/tests/actions/test_network_actions.py
+++ b/tests/actions/test_network_actions.py
@@ -42,22 +42,13 @@ class TestNetworkActions(OpenstackActionTestBase):
         assert returned[0] is False
         assert "could not be found" in returned[1]
 
-    def test_find_rbac_found(self):
+    def test_find_rbac_forwards(self):
         """
-        Tests the action returns the found RBACPolicy object
+        Tests the action returns the found RBACPolicy list as-is
         """
-        returned = self.action.network_rbac_find(NonCallableMock(), NonCallableMock())
-        expected = self.network_mock.find_network_rbac.return_value
-        assert returned == (True, expected)
-
-    def test_find_rbac_not_found(self):
-        """
-        Tests the status and message when a policy isn't found
-        """
-        self.network_mock.find_network_rbac.return_value = None
-        returned = self.action.network_rbac_find(NonCallableMock(), NonCallableMock())
-        assert returned[0] is False
-        assert "could not be found" in returned[1]
+        returned = self.action.network_rbac_search(NonCallableMock(), NonCallableMock())
+        expected = self.network_mock.search_network_rbacs.return_value
+        assert returned == expected
 
     def test_create_network_failed(self):
         """
@@ -173,7 +164,7 @@ class TestNetworkActions(OpenstackActionTestBase):
         """
         expected_methods = [
             "network_find",
-            "network_rbac_find",
+            "network_rbac_search",
             "network_create",
             "network_rbac_create",
             "network_delete",


### PR DESCRIPTION
This is because we cannot name an RBAC so we must search for RBAC's
associated with a project instead.